### PR TITLE
[feat] Show FPS=99+ if FPS is too large

### DIFF
--- a/src/hal/FPS.c
+++ b/src/hal/FPS.c
@@ -7,7 +7,8 @@ static uint32_t lastTime = 0;
 void UpdateFPS(uint32_t now) {
   if (now - lastTime > 1000) {
     int fps = nr_draw * 1000 / (now - lastTime);
-    printf("\r(System time: %6ds) FPS = %2d", now / 1000, fps);
+    if (fps > 99) fps = 99;
+    printf("\r(System time: %6ds) FPS = %2d%c", now / 1000, fps, fps == 99 ? '+' : ' ');
     fflush(stdout);
     nr_draw = 0;
     lastTime = now;


### PR DESCRIPTION
navy 的简化实现容易让 FPS 突然特别高
这时候打印99+, 防止 "\r99999\r10" 显示为 "10999".
